### PR TITLE
Build with  `Libtorch` Error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
+LIBTORCH_PATH ?= /home/mkotak/atomic_architects/lib/libtorch
+
 # Default target
 all: build
 
 # Build target
 build:
-	cmake -Bbuild -DCMAKE_PREFIX_PATH=`python3 -c 'import torch;print(torch.utils.cmake_prefix_path)'`
+	cmake -Bbuild -DCMAKE_PREFIX_PATH=$(LIBTORCH_PATH)
 	cmake --build build
 
 # Run target
 run: build
-	./build/inference ${PWD}/si-deployed.so
+	./build/inference /home/mkotak/atomic_architects/allegro/export/si-deployed.so
 
 # Clean target
 clean:

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@ LIBTORCH_PATH ?= /home/mkotak/atomic_architects/lib/libtorch
 all: build
 
 # Build target
-build:
+build: clean
 	cmake -Bbuild -DCMAKE_PREFIX_PATH=$(LIBTORCH_PATH)
 	cmake --build build
 
 # Run target
-run: build
-	./build/inference /home/mkotak/atomic_architects/allegro/export/si-deployed.so
+run:
+	./build/inference /home/mkotak/atomic_architects/lib/allegro/export/si-deployed.so
 
 # Clean target
 clean:


### PR DESCRIPTION
Getting this error

```bash
./build/inference /home/mkotak/atomic_architects/lib/allegro/export/si-deployed.so
terminate called after throwing an instance of 'c10::DynamicLibraryError'
  what():  Error in dlopen: /home/mkotak/atomic_architects/lib/allegro/export/si-deployed.so: undefined symbol: _ZN3c107WarningC1ESt7variantIJNS0_11UserWarningENS0_18DeprecationWarningEEERKNS_14SourceLocationESsb
Exception raised from DynamicLibrary at ../aten/src/ATen/DynamicLibrary.cpp:36 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0xb0 (0x7f62fdf6e7f0 in /home/mkotak/atomic_architects/lib/libtorch/lib/libc10.so)
frame #1: <unknown function> + 0x11975f9 (0x7f62e612b5f9 in /home/mkotak/atomic_architects/lib/libtorch/lib/libtorch_cpu.so)
frame #2: torch::inductor::AOTIModelContainerRunner::AOTIModelContainerRunner(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) + 0xd7 (0x7f62ea8326c7 in /home/mkotak/atomic_architects/lib/libtorch/lib/libtorch_cpu.so)
frame #3: <unknown function> + 0x6110 (0x55ab3961e110 in ./build/inference)
frame #4: <unknown function> + 0x29d90 (0x7f62869d4d90 in /lib/x86_64-linux-gnu/libc.so.6)
frame #5: __libc_start_main + 0x80 (0x7f62869d4e40 in /lib/x86_64-linux-gnu/libc.so.6)
frame #6: <unknown function> + 0x5d75 (0x55ab3961dd75 in ./build/inference)

make: *** [Makefile:13: run] Aborted (core dumped)
```

while building I see this warning on both `main` and `libtorch`

```bash
CMake Warning at CMakeLists.txt:8 (add_executable):
  Cannot generate a safe runtime search path for target inference because
  files in some directories may conflict with libraries in implicit
  directories:

    runtime library [libnvToolsExt.so.1] in /usr/lib/x86_64-linux-gnu may be hidden by files in:
      /usr/local/cuda-12.5/lib64

  Some of these libraries may not be found correctly.
```